### PR TITLE
possible fix to dark-mode example

### DIFF
--- a/apps/www/registry/default/example/mode-toggle.tsx
+++ b/apps/www/registry/default/example/mode-toggle.tsx
@@ -18,9 +18,11 @@ export default function ModeToggle() {
   return (
     <MenuContainer>
       <MenuButton>
+      <span className="relative flex items-center justify-center">
         <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
         <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
         <span className="sr-only">Toggle theme</span>
+        </span>
       </MenuButton>
       <Menu align="end">
         <MenuItem onClick={() => setTheme("light")}>Light</MenuItem>


### PR DESCRIPTION
Issue: The position of the moon icon is not correct
![image](https://github.com/user-attachments/assets/dd378e75-55af-4f4a-80af-787c2363bb8b)

Fix: Add a span with relative to fix the position